### PR TITLE
doc(readme): items example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ jspm install aurelia-autocomplete
 </auto-complete>
 ```
 
+*or if you have an array with items and thus would not need to perform
+a request*
+
+```js
+export class Page {
+  languages = [ /* languages */ ];
+}
+```
+
+```html
+<auto-complete items.bind="languages"></auto-complete>
+```
+
 > extended
 
 ```js

--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ jspm install aurelia-autocomplete
 > simple
 
 ```html
-<auto-complete
-  resource='language'>
-</auto-complete>
+<auto-complete resource="language"></auto-complete>
 ```
 
 *or if you have an array with items and thus would not need to perform


### PR DESCRIPTION
adds an example to the README.md which shows how to use autocomplete with
a simple array.