### PR TITLE
fix(project): prevent selecting result when search result is empty

### DIFF
--- a/src/component/autocomplete.js
+++ b/src/component/autocomplete.js
@@ -226,7 +226,9 @@ export class AutoCompleteCustomElement {
         event.preventDefault();
       }
 
-      this.onSelect();
+      if (this.results.length !== 0) {
+        this.onSelect();
+      }
     } else {
       this.setFocus(true);
     }


### PR DESCRIPTION
When the string we search on doesn't give any result, if we press ENTER or TAB, the last selected item will be added.

Previous behaviour:
![auto-complete-before](https://user-images.githubusercontent.com/6155967/28206478-538c0962-6886-11e7-86b9-0a4b1e5a531a.gif)

New behaviour:
![auto-complete](https://user-images.githubusercontent.com/6155967/28206501-6c5d7016-6886-11e7-806c-01872f4ce5e6.gif)
