### PR TITLE
Improve behaviour

### DIFF
--- a/src/component/autocomplete.js
+++ b/src/component/autocomplete.js
@@ -223,7 +223,7 @@ export class AutoCompleteCustomElement {
       if (this.results.length !== 0 && this.hasFocus) {
         this.onSelect();
       }
-    } else {
+    } else if (event.keyCode !== 37 && event.keyCode !== 39) {
       this.setFocus(true);
     }
 

--- a/src/component/autocomplete.js
+++ b/src/component/autocomplete.js
@@ -283,6 +283,7 @@ export class AutoCompleteCustomElement {
    */
   valueChanged() {
     if (!this.shouldPerformRequest()) {
+      this.previousValue = this.value;
       return Promise.resolve();
     }
 
@@ -290,6 +291,7 @@ export class AutoCompleteCustomElement {
 
     if (!this.hasEnoughCharacters()) {
       this.results = [];
+      this.previousValue = this.value;
 
       return Promise.resolve();
     }

--- a/src/component/autocomplete.js
+++ b/src/component/autocomplete.js
@@ -148,14 +148,8 @@ export class AutoCompleteCustomElement {
       return true;
     }
 
-    if (!this.hasEnoughCharacters()) {
-      this.hasFocus = false;
-
-      return true;
-    }
-
     if (value) {
-      this.valueChanged();
+      return this.valueChanged();
     }
 
     this.hasFocus = value;
@@ -226,7 +220,7 @@ export class AutoCompleteCustomElement {
         event.preventDefault();
       }
 
-      if (this.results.length !== 0) {
+      if (this.results.length !== 0 && this.hasFocus) {
         this.onSelect();
       }
     } else {
@@ -284,6 +278,8 @@ export class AutoCompleteCustomElement {
   valueChanged() {
     if (!this.shouldPerformRequest()) {
       this.previousValue = this.value;
+      this.hasFocus = !(this.results.length === 0);
+
       return Promise.resolve();
     }
 
@@ -292,9 +288,12 @@ export class AutoCompleteCustomElement {
     if (!this.hasEnoughCharacters()) {
       this.results = [];
       this.previousValue = this.value;
+      this.hasFocus = false;
 
       return Promise.resolve();
     }
+
+    this.hasFocus = true;
 
     // when resource is not defined it will not perform a request. Instead it
     // will search for the first items that pass the predicate


### PR DESCRIPTION
This pull request fixes some unexpected/weird behaviour.

1) Let's say `minInput` is set to `1`. Sometimes, the results of the request won't be shown because it was trying to set `hasFocus` before the `value` was being set.

2) With `minInput` set to `1`. Removing the search string from the input was showing `No results`, but in this specific case we just want to hide the "dropdown" as the minimum of required characters is not reached.

3) On slow network connection, the previous results was sometimes shown.

4) Keep the dropdown's state when using the left/right arrows