### PR TITLE
Update autocomplete.html

### DIFF
--- a/src/component/bootstrap/autocomplete.html
+++ b/src/component/bootstrap/autocomplete.html
@@ -27,7 +27,7 @@
       <li if.bind="lastFindPromise && results.length" role="separator" class="divider"></li>
 
       <li
-        show.bind="results.length === 0 && !lastFindPromise"
+        show.bind="results.length === 0 && lastFindPromise === false"
         class="text-muted"
         t="No results"
         css="padding: 5px 15px ${showFooter ? 0 : 5}px 15px;text-align: center;font-style: italic;"

--- a/src/component/bootstrap/autocomplete.html
+++ b/src/component/bootstrap/autocomplete.html
@@ -27,7 +27,7 @@
       <li if.bind="lastFindPromise && results.length" role="separator" class="divider"></li>
 
       <li
-        show.bind="results.length === 0 && lastFindPromise === false"
+        show.bind="results.length === 0 && lastFindPromise != undefined && !lastFindPromise"
         class="text-muted"
         t="No results"
         css="padding: 5px 15px ${showFooter ? 0 : 5}px 15px;text-align: center;font-style: italic;"


### PR DESCRIPTION
the lastFindPromise is defined on the view model only after the first call to valueChanged, which doesn't happen until after the first setFocus.  This causes the "No results" list item to show because the truthy type coercion of undefined results in false and !lastFindPromise ends up being true.